### PR TITLE
Fix auth session usage

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { Prisma, Status } from "@prisma/client";
-import { getServerSession } from "next-auth/next";
+import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { NextRequest } from "next/server";
 
@@ -18,7 +18,7 @@ const handleServerError = (error: unknown) => {
 
 export async function GET(req: NextRequest) {
   try {
-    const session = await getServerSession({ req, ...authOptions });
+    const session = await getServerSession(authOptions);
 
     if (!session || !session.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   try {
-    const session = await getServerSession({ req, ...authOptions });
+    const session = await getServerSession(authOptions);
 
     if (!session || !session.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/workspaces/current/route.ts
+++ b/src/app/api/workspaces/current/route.ts
@@ -1,12 +1,12 @@
 // src/app/api/workspaces/current/route.ts
 
-import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 
-export async function GET(req: NextRequest) {
-  const session = await getServerSession({ req, ...authOptions });
+export async function GET() {
+  const session = await getServerSession(authOptions);
 
   if (!session?.user?.email) {
     return NextResponse.json({ error: "Não autenticado" }, { status: 401 });


### PR DESCRIPTION
## Summary
- fix calls to `getServerSession` in tasks and workspaces routes

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Module '@prisma/client' has no exported member 'Status')*
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684029f5cc508331bb6a8108904d9f74