### PR TITLE
Fix display dropdown closing behavior

### DIFF
--- a/src/components/CreateTaskModal.tsx
+++ b/src/components/CreateTaskModal.tsx
@@ -35,19 +35,11 @@ function CreateTaskModal({
   const [description, setDescription] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
-  const [isDisplayOpen, setIsDisplayOpen] = useState(false);
 
   const modalRef = useRef<HTMLDivElement>(null);
-  const displayRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (displayRef.current && displayRef.current.contains(event.target as Node)) return;
-      if (isDisplayOpen) {
-        setIsDisplayOpen(false);
-        return;
-      }
-
       if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
         onClose();
       }
@@ -57,7 +49,7 @@ function CreateTaskModal({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isDisplayOpen, onClose]);
+  }, [onClose]);
 
   if (!isOpen) return null;
 
@@ -124,9 +116,7 @@ function CreateTaskModal({
                   </div>
                 )}
               </div>
-                <div className="relative" ref={displayRef}>
-                  <DisplayDropdown />
-                </div>
+              <DisplayDropdown />
             </div>
             <div className="flex gap-2">
               <button

--- a/src/components/DisplayDown.tsx
+++ b/src/components/DisplayDown.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { IoMdOptions } from "react-icons/io";
 
 function DisplayDropdown() {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
 
   const displayOptions = [
@@ -30,8 +31,27 @@ function DisplayDropdown() {
     );
   };
 
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen]);
+
   return (
-    <div className="relative">
+    <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-1 bg-[#2c2c2c] text-white px-3 py-1 rounded-md text-sm border border-gray-700 hover:bg-[#3a3a3a] transition"


### PR DESCRIPTION
## Summary
- close `Exibição` dropdown when clicking outside
- simplify `CreateTaskModal` handler

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b672f5d88331a46b3cac113054e0