### PR TITLE
Fix build crash on /invite

### DIFF
--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+// This page relies on search params from the URL. During the build step,
+// Next.js attempts to pre-render pages by default which causes errors
+// when `useSearchParams` is executed without a request context.
+// Mark the page as dynamic so that it renders at runtime only.
+export const dynamic = 'force-dynamic';
+
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Loader2, AlertCircle, CheckCircle2, ArrowLeft } from 'lucide-react';

--- a/src/app/invite/page.tsx
+++ b/src/app/invite/page.tsx
@@ -7,12 +7,12 @@
 export const dynamic = 'force-dynamic';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { Loader2, AlertCircle, CheckCircle2, ArrowLeft } from 'lucide-react';
 
 type InvitationStatus = 'loading' | 'verified' | 'expired' | 'invalid' | 'accepted' | 'error';
 
-export default function InvitePage() {
+function InvitePageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const [status, setStatus] = useState<InvitationStatus>('loading');
@@ -224,11 +224,19 @@ export default function InvitePage() {
             {status === 'verified' ? 'Bem-vindo(a) ao' : 'Convite para o'} Kanban
           </h1>
         </div>
-        
+
         <div className="mt-8">
           {renderContent()}
         </div>
       </div>
     </div>
+  );
+}
+
+export default function InvitePage() {
+  return (
+    <Suspense fallback={null}>
+      <InvitePageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- mark Invite page as dynamic to avoid build-time pre-render errors

## Testing
- `npm install` *(fails: Failed to fetch checksum from binaries.prisma.sh)*

------
https://chatgpt.com/codex/tasks/task_e_687050de6b84833196c422ea684cb6ef