### PR TITLE
Fix date parsing mismatch in tasks

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -4,6 +4,7 @@ import { Prisma, Status } from "@prisma/client";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { NextRequest } from "next/server";
+import { parseLocalDate } from "@/lib/utils";
 
 const handleServerError = (error: unknown) => {
   // console.error("Server error:", error);
@@ -79,8 +80,8 @@ export async function POST(req: NextRequest) {
         projectId: body.projectId ? Number(body.projectId) : null,
         assignees: body.assignees ?? [],
         labels: body.labels ?? [],
-        startDate: body.startDate || null,
-        dueDate: body.dueDate || null
+        startDate: body.startDate ? parseLocalDate(body.startDate) : null,
+        dueDate: body.dueDate ? parseLocalDate(body.dueDate) : null
       }
     });
 
@@ -153,13 +154,13 @@ export async function PATCH(req: NextRequest) {
 
     // Handle date fields separately to ensure they're proper Date objects
     if (body.startDate) {
-      updateData.startDate = new Date(body.startDate);
+      updateData.startDate = parseLocalDate(body.startDate);
     } else if ('startDate' in body) {
       updateData.startDate = null;
     }
 
     if (body.dueDate) {
-      updateData.dueDate = new Date(body.dueDate);
+      updateData.dueDate = parseLocalDate(body.dueDate);
     } else if ('dueDate' in body) {
       updateData.dueDate = null;
     }

--- a/src/app/dashboard/my-tasks/page.tsx
+++ b/src/app/dashboard/my-tasks/page.tsx
@@ -8,6 +8,7 @@ import WorkItemSidebar from "@/components/WorkItemSidebar";
 import { useSession } from "next-auth/react";
 import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import { format } from "date-fns";
+import { parseLocalDate } from "@/lib/utils";
 import {
   FaPlus,
   FaChevronDown,
@@ -37,6 +38,7 @@ export type WorkItem = {
   labels?: string[];
   creator?: string;
 };
+
 
 export default function KanbanPage() {
   const { data: session, status } = useSession();
@@ -366,16 +368,16 @@ export default function KanbanPage() {
         <div className="flex items-center gap-1 border border-gray-300 rounded-full px-2 py-1">
           {getPriorityIcon(item.priority)}
         </div>
-        {item.startDate && !isNaN(new Date(item.startDate).getTime()) && (
+        {item.startDate && !isNaN(parseLocalDate(item.startDate).getTime()) && (
           <div className="flex items-center gap-1 border border-gray-300 rounded-full px-2 py-1">
             <FaCalendarAlt className="text-gray-500" />
-            <span>Início: {format(new Date(item.startDate), "MMM dd, yyyy")}</span>
+            <span>Início: {format(parseLocalDate(item.startDate), "MMM dd, yyyy")}</span>
           </div>
         )}
         {item.dueDate && (
           <div className="flex items-center gap-1 border border-red-400 text-red-500 rounded-full px-2 py-1">
             <FaCalendarAlt />
-            <span>Prazo: {format(new Date(item.dueDate), "MMM dd, yyyy")}</span>
+            <span>Prazo: {format(parseLocalDate(item.dueDate), "MMM dd, yyyy")}</span>
           </div>
         )}
         {item.creator && (

--- a/src/components/WorkItemSidebar.tsx
+++ b/src/components/WorkItemSidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import "react-datepicker/dist/react-datepicker.css";
 import { FormattedDateInput } from "./FormattedDateInput";
 import type { WorkItem } from "@/app/dashboard/my-tasks/page";
+import { parseLocalDate } from "@/lib/utils";
 import { 
   XMarkIcon, 
   UserCircleIcon, 
@@ -44,7 +45,7 @@ export default function WorkItemSidebar({ item, onClose, onUpdate }: Props) {
   const formatDate = (dateString: string): string => {
     if (!dateString) return 'não definida';
     try {
-      const date = new Date(dateString);
+      const date = parseLocalDate(dateString);
       return date.toLocaleDateString('pt-BR');
     } catch (error) {
       console.error('Error formatting date:', error);

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { cn } from './utils'
+import { cn, parseLocalDate } from './utils'
 
 describe('cn', () => {
   it('combines class names', () => {
@@ -12,5 +12,14 @@ describe('cn', () => {
 
   it('handles conditional values and arrays', () => {
     expect(cn({ hidden: false, block: true }, ['text-sm', 'text-lg'])).toBe('block text-lg')
+  })
+})
+
+describe('parseLocalDate', () => {
+  it('parses ISO date strings as local dates', () => {
+    const d = parseLocalDate('2024-05-21T00:00:00.000Z')
+    expect(d.getFullYear()).toBe(2024)
+    expect(d.getMonth()).toBe(4)
+    expect(d.getDate()).toBe(21)
   })
 })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,8 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function parseLocalDate(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('T')[0].split('-').map(Number)
+  return new Date(year, month - 1, day)
+}


### PR DESCRIPTION
## Summary
- parse dates without timezone offsets
- ensure task API stores parsed dates
- display dates with the new local parser
- test new `parseLocalDate` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888f83fd2cc83318d953be84bdefec9