### PR TITLE
Fix workspace creation with user email

### DIFF
--- a/src/app/api/workspaces/create/route.tsx
+++ b/src/app/api/workspaces/create/route.tsx
@@ -29,5 +29,13 @@ export async function POST(req: Request) {
     },
   });
 
+  await prisma.workspaceMember.create({
+    data: {
+      userId: user.id,
+      workspaceId: workspace.id,
+      role: "ADMIN",
+    },
+  });
+
   return NextResponse.json(workspace, { status: 201 });
 }

--- a/src/app/create-workspace/page.tsx
+++ b/src/app/create-workspace/page.tsx
@@ -3,11 +3,14 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import toast from "react-hot-toast";
+import { useSession } from "next-auth/react";
 
 export default function CriarEspacoTrabalho() {
   const [nomeEspaco, setNomeEspaco] = useState("");
   const [urlEspaco, setUrlEspaco] = useState("");
   const [usuarios, setUsuarios] = useState("");
+
+  const { data: session } = useSession();
 
   const [erros, setErros] = useState({
     nome: false,
@@ -86,7 +89,9 @@ export default function CriarEspacoTrabalho() {
     <div className="min-h-screen bg-white text-gray-900 flex flex-col">
       <header className="flex justify-between items-center px-8 py-6">
         <h1 className="text-xl font-bold">TaskFlow</h1>
-        <span className="text-sm text-gray-600">henri.okayama@gmail.com</span>
+        <span className="text-sm text-gray-600">
+          {session?.user?.email || ""}
+        </span>
       </header>
 
       <main className="flex flex-1 items-center">


### PR DESCRIPTION
## Summary
- show the logged user email on Create Workspace page
- automatically create a WorkspaceMember when a workspace is created

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6889fd6e9e608331aff8ba9a5799cea3