### PR TITLE
fix: go back button on 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,15 @@
+"use client";
+
 import Link from 'next/link';
 import { Home, ArrowLeft } from 'lucide-react';
 
 export default function NotFound() {
+  const handleGoBack = () => {
+    if (typeof window !== 'undefined') {
+      window.history.back();
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center min-h-[calc(100vh-200px)] text-center p-4">
       <div className="space-y-6 max-w-md">
@@ -14,13 +22,13 @@ export default function NotFound() {
         </div>
         
         <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-          <Link 
-            href="/" 
+          <button
+            onClick={handleGoBack}
             className="flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground w-full sm:w-auto"
           >
             <ArrowLeft className="w-4 h-4" />
             Voltar
-          </Link>
+          </button>
           <Link 
             href="/" 
             className="flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 w-full sm:w-auto"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Atualizada a ação “Voltar” na página de erro (404) para usar o histórico do navegador via botão, oferecendo um retorno mais natural à navegação anterior em vez de redirecionar diretamente para a página inicial.
  - Mantida a opção “Ir para a página inicial” como link dedicado, garantindo alternativa rápida para retornar à home.
  - Comportamento geral da página permanece o mesmo, sem impacto visual significativo além da troca do link “Voltar” por um botão.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->