### PR TITLE
Make my-tasks dashboard responsive on mobile

### DIFF
--- a/src/app/[workspaceSlug]/dashboard/my-tasks/page.tsx
+++ b/src/app/[workspaceSlug]/dashboard/my-tasks/page.tsx
@@ -645,14 +645,14 @@ function KanbanPage() {
         </div>
 
       {/* Main content area with view switching */}
-      <div className="flex-1 overflow-x-auto p-3 sm:p-4">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden p-3 sm:p-4 sm:overflow-x-auto">
         {viewType === "kanban" ? (
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={onDragStart} onDragCancel={onDragCancel} onDragEnd={onDragEnd}>
-            <div className="flex gap-4 min-w-full sm:min-w-max">
+            <div className="flex flex-col gap-4 sm:flex-row sm:min-w-max">
               {Object.entries(collapsedColumns).map(([statusKey, isCollapsed]) => {
               const typedStatus = statusKey as Status;
               return (
-                <div key={typedStatus} className="w-[min(18rem,85vw)] sm:w-72 flex-shrink-0">
+                <div key={typedStatus} className="w-full sm:w-72 sm:flex-shrink-0">
                   <div
                     className="flex justify-between items-center bg-gray-100 dark:bg-gray-800 p-2 rounded-t cursor-pointer"
                     onClick={() => toggleColumnCollapse(typedStatus)}
@@ -681,10 +681,10 @@ function KanbanPage() {
                 <ColumnDroppable status={typedStatus}>
                   <div
                     className={`bg-white dark:bg-gray-800 rounded-b overflow-hidden transition-all duration-300 ease-in-out ${
-                      isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[65vh] sm:max-h-[calc(100vh-220px)] opacity-100'
+                      isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[999px] sm:max-h-[calc(100vh-220px)] opacity-100'
                     }`}
                   >
-                    <div className="p-2 space-y-2 max-h-[60vh] overflow-y-auto sm:max-h-none sm:h-[calc(100vh-280px)]">
+                    <div className="p-2 space-y-2 sm:h-[calc(100vh-280px)] sm:overflow-y-auto">
                       {(() => {
                         const columnItems = filteredTasks.filter(item => item.status === typedStatus);
                         return (

--- a/src/app/[workspaceSlug]/dashboard/my-tasks/page.tsx
+++ b/src/app/[workspaceSlug]/dashboard/my-tasks/page.tsx
@@ -606,28 +606,28 @@ function KanbanPage() {
   return (
     <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white">
       <div className="flex-1 flex flex-col">
-        <div className="flex justify-between items-center p-4 border-b border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800">
-          <h1 className="text-xl font-bold">{workspaceName} &gt; Item de Trabalho</h1>
-          <div className="flex gap-2">
-            <div className="relative">
+        <div className="flex flex-col gap-3 p-4 border-b border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-lg font-bold text-center sm:text-left sm:text-xl">{workspaceName} &gt; Item de Trabalho</h1>
+          <div className="flex flex-wrap gap-2 justify-end w-full sm:w-auto">
+            <div className="relative w-full sm:w-auto">
               <button
-                className="flex items-center gap-1 bg-[#2c2c2c] text-white px-3 py-2 rounded-md text-sm border border-gray-700 hover:bg-[#3a3a3a] transition"
+                className="flex w-full items-center justify-center gap-1 bg-[#2c2c2c] text-white px-3 py-2 rounded-md text-sm border border-gray-700 hover:bg-[#3a3a3a] transition"
                 onClick={() => setShowFilter(prev => !prev)}
               >
                 <IoFunnelOutline />
                 Filtros
               </button>
               {showFilter && (
-                <div ref={dropdownRef} className="absolute right-0 mt-2 z-50">
-                  <FilterDropdown 
-                  filters={filters}
-                  onFilterChange={handleFilterChange}
-                />
+                <div ref={dropdownRef} className="absolute left-0 sm:left-auto sm:right-0 mt-2 z-50 w-full sm:w-auto">
+                  <FilterDropdown
+                    filters={filters}
+                    onFilterChange={handleFilterChange}
+                  />
                 </div>
               )}
             </div>
 
-            <DisplayDropdown 
+            <DisplayDropdown
               visibleProperties={displayOptions.visibleProperties}
               showSubtasks={displayOptions.showSubtasks}
               onDisplayOptionChange={handleDisplayOptionChange}
@@ -636,23 +636,23 @@ function KanbanPage() {
               onViewTypeChange={setViewType}
             />
             <button
-              className="flex items-center gap-1 bg-blue-600 px-3 py-2 rounded hover:bg-blue-500 text-sm text-white"
+              className="flex w-full items-center justify-center gap-1 bg-blue-600 px-3 py-2 rounded hover:bg-blue-500 text-sm text-white sm:w-auto"
               onClick={() => setIsCreateModalOpen(true)}
             >
               <FaPlus /> Adicionar novo item
             </button>
-            </div>
+          </div>
         </div>
-        
+
       {/* Main content area with view switching */}
-      <div className="flex-1 overflow-x-auto p-4">
+      <div className="flex-1 overflow-x-auto p-3 sm:p-4">
         {viewType === "kanban" ? (
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={onDragStart} onDragCancel={onDragCancel} onDragEnd={onDragEnd}>
-            <div className="flex gap-4 min-w-max">
+            <div className="flex gap-4 min-w-full sm:min-w-max">
               {Object.entries(collapsedColumns).map(([statusKey, isCollapsed]) => {
               const typedStatus = statusKey as Status;
               return (
-                <div key={typedStatus} className="w-72 flex-shrink-0">
+                <div key={typedStatus} className="w-[min(18rem,85vw)] sm:w-72 flex-shrink-0">
                   <div
                     className="flex justify-between items-center bg-gray-100 dark:bg-gray-800 p-2 rounded-t cursor-pointer"
                     onClick={() => toggleColumnCollapse(typedStatus)}
@@ -679,12 +679,12 @@ function KanbanPage() {
                   </div>
                 {/* Conteúdo da coluna com animação */}
                 <ColumnDroppable status={typedStatus}>
-                  <div 
+                  <div
                     className={`bg-white dark:bg-gray-800 rounded-b overflow-hidden transition-all duration-300 ease-in-out ${
-                      isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[calc(100vh-220px)] opacity-100'
+                      isCollapsed ? 'max-h-0 opacity-0' : 'max-h-[65vh] sm:max-h-[calc(100vh-220px)] opacity-100'
                     }`}
                   >
-                    <div className="p-2 space-y-2 h-[calc(100vh-280px)] overflow-y-auto">
+                    <div className="p-2 space-y-2 max-h-[60vh] overflow-y-auto sm:max-h-none sm:h-[calc(100vh-280px)]">
                       {(() => {
                         const columnItems = filteredTasks.filter(item => item.status === typedStatus);
                         return (

--- a/src/components/DisplayDown.tsx
+++ b/src/components/DisplayDown.tsx
@@ -65,17 +65,17 @@ function DisplayDropdown({
   }, [isOpen]);
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative w-full sm:w-auto" ref={dropdownRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-1 bg-[#2c2c2c] text-white px-3 py-2 rounded-md text-sm border border-gray-700 hover:bg-[#3a3a3a] transition"
+        className="flex w-full items-center justify-center gap-1 bg-[#2c2c2c] text-white px-3 py-2 rounded-md text-sm border border-gray-700 hover:bg-[#3a3a3a] transition sm:w-auto sm:justify-start"
       >
         <IoMdOptions />
         Exibição
       </button>
 
       {isOpen && (
-        <div className="absolute mt-2 w-72 bg-[#1f1f1f] text-white border border-gray-700 rounded-md shadow-lg p-4 z-50">
+        <div className="absolute left-0 mt-2 w-full max-w-[90vw] bg-[#1f1f1f] text-white border border-gray-700 rounded-md shadow-lg p-4 z-50 sm:left-auto sm:right-0 sm:w-72">
           <div className="text-sm font-semibold text-gray-400 mb-2">Tipo de exibição</div>
           
           <div className="flex flex-wrap gap-2 mb-4">

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -35,7 +35,7 @@ interface FilterDropdownProps {
 
 export default function FilterDropdown({ filters, onFilterChange }: FilterDropdownProps) {
   const hasActiveFilters = Object.values(filters).some(filter => filter.length > 0);
-  
+
   const clearAllFilters = () => {
     Object.keys(filters).forEach(filterType => {
       filters[filterType as keyof typeof filters].forEach(value => {
@@ -44,7 +44,7 @@ export default function FilterDropdown({ filters, onFilterChange }: FilterDropdo
     });
   };
   return (
-    <div className="w-72 max-h-[400px] overflow-y-auto bg-[#1f1f1f] text-white border border-gray-700 rounded-md shadow-lg p-4 text-sm z-50">
+    <div className="w-full max-w-[90vw] max-h-[400px] overflow-y-auto bg-[#1f1f1f] text-white border border-gray-700 rounded-md shadow-lg p-4 text-sm z-50 sm:w-72">
       <input
         type="text"
         placeholder="Procurar"

--- a/src/components/WorkItemSidebar.tsx
+++ b/src/components/WorkItemSidebar.tsx
@@ -297,7 +297,7 @@ export default function WorkItemSidebar({ item, onClose, onUpdate, workspaceSlug
   };
 
   return (
-    <aside className="w-[450px] bg-white dark:bg-gray-800 text-gray-900 dark:text-white border-l border-gray-200 dark:border-gray-700 p-6 overflow-y-auto h-screen fixed right-0 top-0 z-50 shadow-xl">
+    <aside className="w-full max-w-full bg-white dark:bg-gray-800 text-gray-900 dark:text-white border-l border-gray-200 dark:border-gray-700 p-4 overflow-y-auto h-full fixed right-0 top-0 z-50 shadow-xl sm:w-[450px] sm:p-6 sm:h-screen">
       <div className="flex justify-between items-center mb-6 pb-4 border-b border-gray-100 dark:border-gray-700">
         <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center gap-2">
           <span className="text-blue-600 dark:text-blue-400">#{item.id.startsWith('PRIME-') ? item.id : `PRIME-${item.id}`}</span>


### PR DESCRIPTION
## Summary
- allow the my-tasks header actions to wrap so controls are usable on small screens
- constrain filter/display dropdowns and kanban columns for narrow viewports
- let the work item sidebar expand to the full width on mobile devices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8cb49bb7483318828cc7a14e1e832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Melhorias**
  * Reflow do painel Kanban para layouts responsivos (colunas empilhadas em telas pequenas, rolamento vertical).
  * Controles (Filtros, Display, Criar) e dropdowns adaptam largura/posicionamento conforme o viewport.
  * Sidebar de item torna-se full-width em dispositivos móveis e fixa em larguras maiores.
  * Ajustes de altura/overflow para melhorar comportamento de scroll e consistência entre breakpoints.
  * Comportamento de arrastar e soltar preservado com estrutura responsiva atualizada.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->