### PR TITLE
Ensure Google auth sessions retain user details

### DIFF
--- a/src/lib/auth-options.ts
+++ b/src/lib/auth-options.ts
@@ -68,8 +68,15 @@ export const authOptions: NextAuthConfig = {
       token: JWT;
       user: User | undefined;
     }) {
-      if (user) {
-        token.id = user.id;
+      const tokenUserId = user?.id || token.sub;
+      if (tokenUserId) {
+        token.id = tokenUserId;
+
+        // Ensure token always carries email information for OAuth flows
+        // where the user object might not be sent in subsequent requests.
+        if (!token.email && user?.email) {
+          token.email = user.email;
+        }
       }
       return token;
     },
@@ -80,11 +87,25 @@ export const authOptions: NextAuthConfig = {
       session: Session;
       token: JWT;
     }) {
-      if (session.user && token?.id) {
-        session.user.id = String(token.id);
+      if (session.user && (token?.id || token?.sub || session.user.email)) {
+        const userId = String(token.id || token.sub || session.user.id);
+        session.user.id = userId;
+
+        const dbUser = await prisma.user.findUnique({
+          where: {
+            id: userId,
+          },
+          select: {
+            email: true,
+            name: true,
+          },
+        });
+
+        session.user.email = session.user.email || dbUser?.email || null;
+        session.user.name = session.user.name || dbUser?.name || null;
 
         const accounts = await prisma.account.findMany({
-          where: { userId: String(token.id) },
+          where: { userId },
         });
 
         const hasGoogle = accounts.some(


### PR DESCRIPTION
## Summary
- persist user id and email on JWT/session callbacks to stabilize OAuth logins
- hydrate session user data from the database and detect Google-linked accounts reliably

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ed1d0be2c8331af60b2410949c644)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorada confiabilidade da autenticação OAuth ao garantir que o email do usuário é corretamente preservado nas sessões mesmo quando ausente em requisições subsequentes.
  * Reforçada robustez do sistema de autenticação contra dados faltantes em fluxos OAuth, com tratamento explícito de cenários especiais.
  * Otimizado enriquecimento automático de dados de perfil do usuário (email e nome) recuperados do banco de dados quando não fornecidos pela sessão.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->